### PR TITLE
Add `pcbVer` to PDVersion

### DIFF
--- a/src/PlaydateDevice.ts
+++ b/src/PlaydateDevice.ts
@@ -187,6 +187,7 @@ export class PlaydateDevice {
     assert('pdxversion' in parsed);
     assert('serial#' in parsed);
     assert('target' in parsed);
+    assert('pcbver' in parsed);
     // format keys as an object
     return {
       sdk: parsed['SDK'],
@@ -196,6 +197,7 @@ export class PlaydateDevice {
       pdxVersion: parsed['pdxversion'],
       serial: parsed['serial#'],
       target: parsed['target'],
+      pcbVer: parsed['pcbver'],
     };
   }
 

--- a/src/PlaydateTypes.ts
+++ b/src/PlaydateTypes.ts
@@ -9,6 +9,7 @@ export interface PDVersion {
   pdxVersion: string;
   serial: string;
   target: string;
+  pcbVer: string;
 };
 
 /**


### PR DESCRIPTION
I believe this was added in firmware 2.0.0, but haven't confirmed myself: https://devforum.play.date/t/how-to-tell-a-playdates-hardware-revision-from-the-simulator/12467

Might be considered a breaking change as written. I'm happy to change so it's not, or feel free to adjust how you see fit.